### PR TITLE
fix: github-username catch error

### DIFF
--- a/src/utils/getGithubUser.ts
+++ b/src/utils/getGithubUser.ts
@@ -14,7 +14,7 @@ export const getGithubUser = async () => {
   if (githubUser) {
     return githubUser;
   } else if (email) {
-    return await githubUsername(email);
+    return await githubUsername(email).catch(() => undefined);
   }
 
   return undefined;


### PR DESCRIPTION
Since `sindresorhus/github-username` throws error if it cannot find a matching username, we should catch that error and return undefined instead.